### PR TITLE
fix mod:volts expected prefix of units:unit

### DIFF
--- a/source/mod-audio-to-cv/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
+++ b/source/mod-audio-to-cv/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-audio-to-cv>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -68,7 +69,7 @@ lv2:port
     lv2:default 0.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ]
 ,
 [

--- a/source/mod-cv-attenuverter/mod-cv-attenuverter.lv2/mod-cv-attenuverter.ttl
+++ b/source/mod-cv-attenuverter/mod-cv-attenuverter.lv2/mod-cv-attenuverter.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units:  <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-cv-attenuverter>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -66,7 +67,7 @@ lv2:port
     lv2:default 0.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort ,lv2:ControlPort ;

--- a/source/mod-cv-control/mod-cv-control.lv2/mod-cv-control.ttl
+++ b/source/mod-cv-control/mod-cv-control.lv2/mod-cv-control.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units:  <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-cv-control>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -50,7 +51,7 @@ lv2:port
     lv2:default 1.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort, lv2:ControlPort ;

--- a/source/mod-cv-gate/mod-cv-gate.lv2/mod-cv-gate.ttl
+++ b/source/mod-cv-gate/mod-cv-gate.lv2/mod-cv-gate.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units:  <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-cv-gate>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -42,7 +43,7 @@ lv2:port
     lv2:maximum 10.0 ;
     lv2:symbol "Gate";
     lv2:name "Gate";
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort, lv2:CVPort, mod:CVPort;
@@ -69,7 +70,7 @@ lv2:port
     lv2:default 1.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort ,
@@ -80,7 +81,7 @@ lv2:port
     lv2:default 0.9 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort ,

--- a/source/mod-cv-random/mod-cv-random.lv2/mod-cv-random.ttl
+++ b/source/mod-cv-random/mod-cv-random.lv2/mod-cv-random.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units:  <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-cv-random>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -61,7 +62,7 @@ lv2:port
     lv2:default 0.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ]
 ,
 [
@@ -73,7 +74,7 @@ lv2:port
     lv2:default 1.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ]
 ,
 [

--- a/source/mod-cv-range/mod-cv-range.lv2/mod-cv-range.ttl
+++ b/source/mod-cv-range/mod-cv-range.lv2/mod-cv-range.ttl
@@ -9,6 +9,7 @@
 @prefix atom: <http://lv2plug.in/ns/ext/atom#> .
 @prefix midi: <http://lv2plug.in/ns/ext/midi#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+@prefix units:  <http://lv2plug.in/ns/extensions/units#> .
 
 <http://moddevices.com/plugins/mod-devel/mod-cv-range>
 a lv2:Plugin, mod:ControlVoltagePlugin;
@@ -69,7 +70,7 @@ lv2:port
     lv2:default 0.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort ,
@@ -80,7 +81,7 @@ lv2:port
     lv2:default 10.0 ;
     lv2:minimum -10.0 ;
     lv2:maximum 10.0 ;
-    mod:volts ;
+    units:unit mod:volts ;
 ],
 [
     a lv2:InputPort ,


### PR DESCRIPTION
Without this explicit units:unit prefix, starting mod-ui with these plugins installed resulted in the following errors on the command line:

```
error: /usr/lib/lv2/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl:71:14: expected prefixed name
error: /usr/lib/lv2/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl:71:14: expected `]', not `;'
lilv_world_load_file(): error: Error loading file `file:///usr/lib/lv2/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl'
```

Trying to drag the plugins in the mod-ui from the bottom shelf into the main board resulted in an error message popping up without the plugin appearing on the board.

Looking at another commit I found what looks like the proper way to use mod:volts (https://github.com/moddevices/lv2-data-creative-commons/commit/36796c937d2af815a0c819e22c75ce9db712c52f)
and using that format, then mod-ui successfully loads the plugins and I can use them.